### PR TITLE
Bower registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Recordmp3js
 Record MP3 files directly from the browser using JS and HTML
 
 
+Install
+=======
+
+
+```bash
+$ bower install recordmp3js --save
+```
+
+
 License
 =======
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "Recordmp3js",
+  "version": "0.1.0",
+  "homepage": "https://github.com/nusofthq/Recordmp3js",
+  "authors": [
+    "nusofthq <contact@nusofthq.com>"
+  ],
+  "description": "Record MP3 files directly from the browser using JS and HTML",
+  "main": "js/recordmp3.js",
+  "keywords": [
+    "audio"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Recordmp3js",
+  "name": "recordmp3js",
   "version": "0.1.0",
   "homepage": "https://github.com/nusofthq/Recordmp3js",
   "authors": [
@@ -16,6 +16,11 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
-  ]
+    "tests",
+    "upload.php",
+    "js/jquery-1.11.0.min.js"
+  ],
+  "dependencies": {
+    "jquery": "1.11.0"
+  }
 }


### PR DESCRIPTION
We want to use your package but we use bower registry for managing vendor js dependancies. in this pull request sets up the bower for you so that others could use it too  
more info about bower: http://bower.io

This means others can use your package by doing:
```bash
$ bower install Recordmp3js --save
```